### PR TITLE
Make node structs and their contents public

### DIFF
--- a/crates/markdown-it-block-spoiler/src/lib.rs
+++ b/crates/markdown-it-block-spoiler/src/lib.rs
@@ -24,8 +24,8 @@ use markdown_it::{
 };
 
 #[derive(Debug)]
-struct BlockSpoiler {
-    visible_text: String,
+pub struct BlockSpoiler {
+    pub visible_text: String,
 }
 
 impl NodeValue for BlockSpoiler {

--- a/crates/markdown-it-ruby/src/lib.rs
+++ b/crates/markdown-it-ruby/src/lib.rs
@@ -22,8 +22,8 @@ use markdown_it::{
 
 #[derive(Debug)]
 pub struct Ruby {
-    base_text: String,
-    ruby_text: String,
+    pub base_text: String,
+    pub ruby_text: String,
 }
 
 impl NodeValue for Ruby {

--- a/crates/markdown-it-sub/src/lib.rs
+++ b/crates/markdown-it-sub/src/lib.rs
@@ -17,7 +17,7 @@
 use markdown_it::{generics::inline::emph_pair, MarkdownIt, Node, NodeValue, Renderer};
 
 #[derive(Debug)]
-struct Sub;
+pub struct Sub;
 
 impl NodeValue for Sub {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {

--- a/crates/markdown-it-sup/src/lib.rs
+++ b/crates/markdown-it-sup/src/lib.rs
@@ -17,7 +17,7 @@
 use markdown_it::{generics::inline::emph_pair, MarkdownIt, Node, NodeValue, Renderer};
 
 #[derive(Debug)]
-struct Sup;
+pub struct Sup;
 
 impl NodeValue for Sup {
     fn render(&self, node: &Node, fmt: &mut dyn Renderer) {


### PR DESCRIPTION
I need this for creating markdown widget. And in markdown-it such things are public too.